### PR TITLE
Enable tree-shaking in libraries

### DIFF
--- a/.syncpackrc.js
+++ b/.syncpackrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'bugs',
     'repository',
     'workspaces',
+    'sideEffects',
     'files',
     'main',
     'module',

--- a/contracts/core-contracts/package.json
+++ b/contracts/core-contracts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/contracts/forum-contracts/package.json
+++ b/contracts/forum-contracts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/contracts/users-contracts/package.json
+++ b/contracts/users-contracts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -15,9 +15,9 @@
     "stylelint-fix": "yarn stylelint-base-config --fix",
     "test": "yarn test-linter && yarn test-type && yarn test-unit",
     "test-linter": "yarn linter-base-config src",
+    "test-stylelint": "yarn stylelint-base-config **/*.{ts,tsx}",
     "test-type": "tsc --noEmit",
-    "test-unit": "jest --runInBand --collectCoverage --logHeapUsage --passWithNoTests",
-    "test-stylelint": "yarn stylelint-base-config **/*.{ts,tsx}"
+    "test-unit": "jest --runInBand --collectCoverage --logHeapUsage --passWithNoTests"
   },
   "dependencies": {
     "@emotion/react": "^11.8.1",

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/serverless-configuration/package.json
+++ b/packages/serverless-configuration/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/serverless-helpers/package.json
+++ b/packages/serverless-helpers/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/tools/generators/library/typed-json-config/package.json.ts
+++ b/tools/generators/library/typed-json-config/package.json.ts
@@ -8,6 +8,7 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
   private: true,
   version: '1.0.0',
   license: 'UNLICENSED',
+  sideEffects: false,
   files: ['dist'],
   main: 'dist/cjs/index.js',
   module: 'dist/esm/index.js',

--- a/tools/generators/types/PackageJson.ts
+++ b/tools/generators/types/PackageJson.ts
@@ -4,6 +4,7 @@ export interface PackageJson {
   private: boolean;
   version: string;
   license: string;
+  sideEffects: boolean;
   files: string[];
   main: string;
   module: string;


### PR DESCRIPTION
This PR enables libraries tree-shaking to remove useless code from handlers.

### Example for a single lambda `createAuthChallenge`

Before, 8.68MB:
![screenshot_2022-03-08-14:14:57](https://user-images.githubusercontent.com/19605940/157247614-d512752b-eb64-4261-94f9-80f934abaff7.png)
After, 287KB:
![screenshot_2022-03-08-14:15:05](https://user-images.githubusercontent.com/19605940/157247616-92996f8f-a6b8-447d-ab9b-f6ece7069dc1.png)


### Example for a whole `authentication` package

Before:
![image](https://user-images.githubusercontent.com/19605940/157248469-1020eeb2-8e15-4bb0-852c-db60eebe6dea.png)
After:
![image](https://user-images.githubusercontent.com/19605940/157248349-c089606d-abd8-4483-a766-ba9b1639fde2.png)

