### PR TITLE
Add directory option to generators

### DIFF
--- a/tools/generators/helpers/createFiles.ts
+++ b/tools/generators/helpers/createFiles.ts
@@ -10,7 +10,7 @@ export const createFiles = (
 ): void => {
   const { className, name, propertyName } = names(options.name);
 
-  generateFiles(tree, sourcePath, options.projectRoot, {
+  generateFiles(tree, sourcePath, options.packageRoot, {
     ...options,
     dot: '.',
     className,
@@ -19,13 +19,13 @@ export const createFiles = (
     cliCommand: 'nx',
     strict: undefined,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    offsetFromRoot: offsetFromRoot(options.packageRoot),
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
 
   if (options.unitTestRunner === 'none') {
     tree.delete(
-      join(options.projectRoot, 'src/lib', `${options.fileName}.spec.ts`),
+      join(options.packageRoot, 'src/lib', `${options.fileName}.spec.ts`),
     );
   }
 };

--- a/tools/generators/helpers/createFiles.ts
+++ b/tools/generators/helpers/createFiles.ts
@@ -1,4 +1,4 @@
-import { generateFiles, names, offsetFromRoot, Tree } from '@nrwl/devkit';
+import { generateFiles, names, Tree } from '@nrwl/devkit';
 import { join } from 'path';
 
 import { NormalizedSchema } from '../types';
@@ -19,7 +19,6 @@ export const createFiles = (
     cliCommand: 'nx',
     strict: undefined,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.packageRoot),
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
 

--- a/tools/generators/helpers/normalizeOptions.ts
+++ b/tools/generators/helpers/normalizeOptions.ts
@@ -19,11 +19,7 @@ export const normalizeOptions = (
   generatorType: GeneratorType,
 ): NormalizedSchema => {
   const name = names(options.name).fileName;
-  options.directory =
-    options.directory !== undefined && options.directory !== ''
-      ? options.directory
-      : GeneratorTypeToDirectory[generatorType];
-  const projectRoot = joinPathFragments(
+  const packageRoot = joinPathFragments(
     names(options.directory).fileName,
     name,
   );
@@ -48,6 +44,7 @@ export const normalizeOptions = (
     importPath,
     linter,
     name: projectName,
+    packageRoot,
     projectRoot,
     unitTestRunner,
     workspaceName: npmScope,

--- a/tools/generators/helpers/normalizeOptions.ts
+++ b/tools/generators/helpers/normalizeOptions.ts
@@ -5,6 +5,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { Linter } from '@nrwl/linter';
+import { relative } from 'path';
 
 import {
   GeneratorType,
@@ -34,7 +35,7 @@ export const normalizeOptions = (
     pascalCaseFiles: false,
   });
   const { npmScope } = getWorkspaceLayout(tree);
-
+  const offsetFromRoot = relative(packageRoot, tree.root);
   const importPath = formatImportPath(generatorType, projectName);
 
   return {
@@ -45,7 +46,7 @@ export const normalizeOptions = (
     linter,
     name: projectName,
     packageRoot,
-    projectRoot,
+    offsetFromRoot,
     unitTestRunner,
     workspaceName: npmScope,
   };

--- a/tools/generators/helpers/packageGenerator.ts
+++ b/tools/generators/helpers/packageGenerator.ts
@@ -16,7 +16,7 @@ interface PackageGeneratorParams {
   sourcePath: string;
   packageJson: (options: NormalizedSchema) => PackageJson;
   packageProjectJson: (root: string) => ProjectConfiguration;
-  packageTsConfig: TsConfig;
+  packageTsConfig: (options: NormalizedSchema) => TsConfig;
 }
 
 export const packageGenerator = ({
@@ -35,7 +35,11 @@ export const packageGenerator = ({
     packageJson(options),
   );
 
-  writeJson(tree, join(options.packageRoot, `tsconfig.json`), packageTsConfig);
+  writeJson(
+    tree,
+    join(options.packageRoot, `tsconfig.json`),
+    packageTsConfig(options),
+  );
 
   const projectConfiguration = packageProjectJson(options.packageRoot);
   addProjectConfiguration(tree, options.importPath, projectConfiguration);

--- a/tools/generators/helpers/packageGenerator.ts
+++ b/tools/generators/helpers/packageGenerator.ts
@@ -31,13 +31,13 @@ export const packageGenerator = ({
 
   writeJson(
     tree,
-    join(options.projectRoot, `package.json`),
+    join(options.packageRoot, `package.json`),
     packageJson(options),
   );
 
-  writeJson(tree, join(options.projectRoot, `tsconfig.json`), packageTsConfig);
+  writeJson(tree, join(options.packageRoot, `tsconfig.json`), packageTsConfig);
 
-  const projectConfiguration = packageProjectJson(options.projectRoot);
+  const projectConfiguration = packageProjectJson(options.packageRoot);
   addProjectConfiguration(tree, options.importPath, projectConfiguration);
 
   updateCodeWorkspace(tree, options);

--- a/tools/generators/helpers/symlink.ts
+++ b/tools/generators/helpers/symlink.ts
@@ -9,8 +9,8 @@ export const symlinkVsCodeConfiguration = (
   options: NormalizedSchema,
 ): void => {
   const relativePath = relative(
-    options.projectRoot,
+    options.packageRoot,
     join(tree.root, 'commonConfiguration/.vscode'),
   );
-  symlinkSync(relativePath, join(options.projectRoot, '.vscode'), 'dir');
+  symlinkSync(relativePath, join(options.packageRoot, '.vscode'), 'dir');
 };

--- a/tools/generators/helpers/symlink.ts
+++ b/tools/generators/helpers/symlink.ts
@@ -1,16 +1,12 @@
-import { Tree } from '@nrwl/devkit';
 import { symlinkSync } from 'fs';
-import { join, relative } from 'path';
+import { join } from 'path';
 
 import { NormalizedSchema } from '../types';
 
-export const symlinkVsCodeConfiguration = (
-  tree: Tree,
-  options: NormalizedSchema,
-): void => {
-  const relativePath = relative(
-    options.packageRoot,
-    join(tree.root, 'commonConfiguration/.vscode'),
+export const symlinkVsCodeConfiguration = (options: NormalizedSchema): void => {
+  const relativePath = join(
+    options.offsetFromRoot,
+    'commonConfiguration/.vscode',
   );
   symlinkSync(relativePath, join(options.packageRoot, '.vscode'), 'dir');
 };

--- a/tools/generators/helpers/updateCodeWorkspace.ts
+++ b/tools/generators/helpers/updateCodeWorkspace.ts
@@ -34,7 +34,7 @@ export const updateCodeWorkspace = (
     `${options.workspaceName}.code-workspace`,
     (json: CodeWorkspaceType) => {
       json.folders.push({
-        path: options.projectRoot,
+        path: options.packageRoot,
         name: formatFolderName(options),
       });
 

--- a/tools/generators/library/files/.eslintrc.js__tmpl__
+++ b/tools/generators/library/files/.eslintrc.js__tmpl__
@@ -1,4 +1,4 @@
-const generateImportOrderRule = require('../../commonConfiguration/generateImportOrderRule');
+const generateImportOrderRule = require('<%= offsetFromRoot %>/commonConfiguration/generateImportOrderRule');
 
 module.exports = {
   rules: generateImportOrderRule(__dirname),

--- a/tools/generators/library/files/.lintstagedrc.js__tmpl__
+++ b/tools/generators/library/files/.lintstagedrc.js__tmpl__
@@ -1,2 +1,2 @@
-const baseConfig = require('../../.lintstagedrc.js');
+const baseConfig = require('<%= offsetFromRoot %>/.lintstagedrc.js');
 module.exports = baseConfig;

--- a/tools/generators/library/files/babel.config.js
+++ b/tools/generators/library/files/babel.config.js
@@ -1,3 +1,0 @@
-const commonBabelConfig = require('../../commonConfiguration/babel.config');
-
-module.exports = commonBabelConfig();

--- a/tools/generators/library/files/babel.config.js__tmpl__
+++ b/tools/generators/library/files/babel.config.js__tmpl__
@@ -1,0 +1,3 @@
+const commonBabelConfig = require('<%= offsetFromRoot %>/commonConfiguration/babel.config');
+
+module.exports = commonBabelConfig();

--- a/tools/generators/library/index.ts
+++ b/tools/generators/library/index.ts
@@ -31,7 +31,7 @@ export default async (tree: Tree, schema: Schema): Promise<() => void> => {
   });
   writeJson(
     tree,
-    join(options.projectRoot, `tsconfig.build.json`),
+    join(options.packageRoot, `tsconfig.build.json`),
     packageBuildTsConfig,
   );
   await formatFiles(tree);

--- a/tools/generators/library/index.ts
+++ b/tools/generators/library/index.ts
@@ -37,7 +37,7 @@ export default async (tree: Tree, schema: Schema): Promise<() => void> => {
   await formatFiles(tree);
 
   return () => {
-    symlinkVsCodeConfiguration(tree, options);
+    symlinkVsCodeConfiguration(options);
     installPackagesTask(tree, true);
   };
 };

--- a/tools/generators/library/schema.json
+++ b/tools/generators/library/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "library-generator",
   "type": "object",
@@ -11,6 +10,11 @@
         "$source": "argv",
         "index": 0
       }
+    },
+    "directory": {
+      "type": "string",
+      "description": "Directory of the new library",
+      "default": "packages"
     }
   },
   "required": ["name"]

--- a/tools/generators/library/typed-json-config/package.json.ts
+++ b/tools/generators/library/typed-json-config/package.json.ts
@@ -55,7 +55,7 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
   nx: {
     targets: {
       package: {
-        outputs: [join(options.projectRoot, 'dist')],
+        outputs: [join(options.packageRoot, 'dist')],
       },
     },
   },

--- a/tools/generators/library/typed-json-config/tsconfig.json.ts
+++ b/tools/generators/library/typed-json-config/tsconfig.json.ts
@@ -1,7 +1,9 @@
-import { TsConfig } from '../../types';
+import { joinPathFragments } from '@nrwl/devkit';
 
-export const packageTsConfig: TsConfig = {
-  extends: '../../tsconfig.json',
+import { NormalizedSchema, TsConfig } from '../../types';
+
+export const packageTsConfig = (options: NormalizedSchema): TsConfig => ({
+  extends: joinPathFragments(options.offsetFromRoot, 'tsconfig.json'),
   compilerOptions: {
     baseUrl: 'src',
     composite: true,
@@ -12,4 +14,4 @@ export const packageTsConfig: TsConfig = {
   },
   exclude: ['./dist'],
   include: ['./**/*.ts'],
-};
+});

--- a/tools/generators/service/files/.eslintrc.js__tmpl__
+++ b/tools/generators/service/files/.eslintrc.js__tmpl__
@@ -1,4 +1,4 @@
-const generateImportOrderRule = require('../../commonConfiguration/generateImportOrderRule');
+const generateImportOrderRule = require('<%= offsetFromRoot %>/commonConfiguration/generateImportOrderRule');
 
 module.exports = {
   rules: generateImportOrderRule(__dirname),

--- a/tools/generators/service/files/.lintstagedrc.js__tmpl__
+++ b/tools/generators/service/files/.lintstagedrc.js__tmpl__
@@ -1,2 +1,2 @@
-const baseConfig = require('../../.lintstagedrc.js');
+const baseConfig = require('<%= offsetFromRoot %>/.lintstagedrc.js');
 module.exports = baseConfig;

--- a/tools/generators/service/index.ts
+++ b/tools/generators/service/index.ts
@@ -26,7 +26,7 @@ export default async (tree: Tree, schema: Schema): Promise<() => void> => {
   await formatFiles(tree);
 
   return () => {
-    symlinkVsCodeConfiguration(tree, options);
+    symlinkVsCodeConfiguration(options);
     installPackagesTask(tree, true);
   };
 };

--- a/tools/generators/service/schema.json
+++ b/tools/generators/service/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "service-generator",
   "type": "object",
@@ -11,6 +10,11 @@
         "$source": "argv",
         "index": 0
       }
+    },
+    "directory": {
+      "type": "string",
+      "description": "Directory of the new service",
+      "default": "backend"
     }
   },
   "required": ["name"]

--- a/tools/generators/service/typed-json-config/tsconfig.json.ts
+++ b/tools/generators/service/typed-json-config/tsconfig.json.ts
@@ -1,20 +1,42 @@
-import { TsConfig } from '../../types';
+import { joinPathFragments } from '@nrwl/devkit';
 
-export const packageTsConfig: TsConfig = {
-  extends: '../../tsconfig.json',
+import { NormalizedSchema, TsConfig } from '../../types';
+
+export const packageTsConfig = (options: NormalizedSchema): TsConfig => ({
+  extends: joinPathFragments(options.offsetFromRoot, 'tsconfig.json'),
   compilerOptions: {
     preserveSymlinks: true,
     baseUrl: '.',
     esModuleInterop: true,
   },
   references: [
-    { path: '../../contracts/core-contracts/tsconfig.build.json' },
-    { path: '../../packages/configuration/tsconfig.build.json' },
-    { path: '../../packages/serverless-configuration/tsconfig.build.json' },
-    { path: '../../packages/serverless-helpers/tsconfig.build.json' },
+    {
+      path: joinPathFragments(
+        options.offsetFromRoot,
+        'contracts/core-contracts/tsconfig.build.json',
+      ),
+    },
+    {
+      path: joinPathFragments(
+        options.offsetFromRoot,
+        'packages/configuration/tsconfig.build.json',
+      ),
+    },
+    {
+      path: joinPathFragments(
+        options.offsetFromRoot,
+        'packages/serverless-configuration/tsconfig.build.json',
+      ),
+    },
+    {
+      path: joinPathFragments(
+        options.offsetFromRoot,
+        'packages/serverless-helpers/tsconfig.build.json',
+      ),
+    },
   ],
   include: ['./**/*.ts'],
   'ts-node': {
     files: true,
   },
-};
+});

--- a/tools/generators/types/Shema.ts
+++ b/tools/generators/types/Shema.ts
@@ -14,7 +14,7 @@ export interface NormalizedSchema extends Schema {
   importPath: string;
   linter: Linter;
   name: string;
-  projectRoot: string;
+  packageRoot: string;
   unitTestRunner: 'jest' | 'none';
   workspaceName: string;
 }

--- a/tools/generators/types/Shema.ts
+++ b/tools/generators/types/Shema.ts
@@ -4,7 +4,7 @@ import { GeneratorType } from './GeneratorType';
 
 export interface Schema {
   name: string;
-  directory?: string;
+  directory: string;
   skipJestConfig?: boolean;
 }
 

--- a/tools/generators/types/Shema.ts
+++ b/tools/generators/types/Shema.ts
@@ -15,6 +15,7 @@ export interface NormalizedSchema extends Schema {
   linter: Linter;
   name: string;
   packageRoot: string;
+  offsetFromRoot: string;
   unitTestRunner: 'jest' | 'none';
   workspaceName: string;
 }


### PR DESCRIPTION
We can now pass the directory where the package should be created as option

It does not change the naming convention of the package, or its display in the workspace