### PR TITLE
fix(nx): make nx command work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "@nrwl/cli": "^13.9.2",
-    "@nrwl/devkit": "^13.9.2",
-    "@nrwl/linter": "^13.9.2",
-    "@nrwl/tao": "^13.9.2",
-    "@nrwl/workspace": "^13.9.2",
+    "@nrwl/devkit": "^13.9.5",
+    "@nrwl/linter": "^13.9.5",
+    "@nrwl/tao": "^13.9.5",
+    "@nrwl/workspace": "^13.9.5",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
@@ -55,6 +54,7 @@
     "lint-staged": "^12.3.7",
     "lodash": "^4.17.21",
     "npm-audit-resolver": "^3.0.0-7",
+    "nx": "^13.9.5",
     "prettier": "^2.6.1",
     "syncpack": "^6.2.0",
     "typescript": "^4.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,38 +3517,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nrwl/cli@npm:13.9.2, @nrwl/cli@npm:^13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/cli@npm:13.9.2"
+"@nrwl/cli@npm:13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/cli@npm:13.9.5"
   dependencies:
-    nx: 13.9.2
-  bin:
-    nx: bin/nx.js
-  checksum: ce1e577c24a3caf26e2941381e70ea286825a9ee9e61290155e1dc7741c68726eeb475c30825ecf823acafc385b0aae891fee84318c2f98a6683b8fdbfd893aa
+    nx: 13.9.5
+  checksum: 8877646ef39fa062736e28b9fb4cba33cc4f8bbcf0e1c739e4fff2ca299ac582f49bed80560d1fb085b7d663b7bcc69de668d5114a4ea1a1d69f279506c6b6a7
   languageName: node
   linkType: hard
 
-"@nrwl/devkit@npm:13.9.2, @nrwl/devkit@npm:^13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/devkit@npm:13.9.2"
+"@nrwl/devkit@npm:13.9.5, @nrwl/devkit@npm:^13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/devkit@npm:13.9.5"
   dependencies:
     ejs: ^3.1.5
     ignore: ^5.0.4
-    nx: 13.9.2
+    nx: 13.9.5
     rxjs: ^6.5.4
     semver: 7.3.4
     tslib: ^2.3.0
-  checksum: d87179230358669f3263418e3759a9957c28c4effb78416d1b48a4b9946fb4dd8c9d7f39f4be0725e2e92d5f26b1fa9388a2cf2cea51007e1f882d67dd9ac5df
+  checksum: 89f83630bf229fc20f739c9bbca898d7cbf6eb4ab79fd4da9083d116dddeb0eae7bc2ee635f652d4a59161d510f740e49a7eeccac3f0405177b54318e46ebc79
   languageName: node
   linkType: hard
 
-"@nrwl/jest@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/jest@npm:13.9.2"
+"@nrwl/jest@npm:13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/jest@npm:13.9.5"
   dependencies:
     "@jest/reporters": 27.2.2
     "@jest/test-result": 27.2.2
-    "@nrwl/devkit": 13.9.2
+    "@nrwl/devkit": 13.9.5
     chalk: 4.1.0
     identity-obj-proxy: 3.0.0
     jest-config: 27.2.2
@@ -3557,16 +3555,16 @@ __metadata:
     resolve.exports: 1.1.0
     rxjs: ^6.5.4
     tslib: ^2.3.0
-  checksum: 5fe4f6839a5a6797db3772d3501be89f70dd120c3364ccc593aa7cb16bed611bc576b50346350ca65c0cffdee377eef8362770a674ec8b9a5651b90805b32ddb
+  checksum: 3c0d79e4ccf1aac5a2b6625fccb94e792afe5e158798e3a709b09de2ff657274b20e91094d4ff3df1b8625fedca0ae77fed72f7f1e5feaea62174582f2a5bdfa
   languageName: node
   linkType: hard
 
-"@nrwl/linter@npm:13.9.2, @nrwl/linter@npm:^13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/linter@npm:13.9.2"
+"@nrwl/linter@npm:13.9.5, @nrwl/linter@npm:^13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/linter@npm:13.9.5"
   dependencies:
-    "@nrwl/devkit": 13.9.2
-    "@nrwl/jest": 13.9.2
+    "@nrwl/devkit": 13.9.5
+    "@nrwl/jest": 13.9.5
     "@phenomnomnominal/tsquery": 4.1.1
     tmp: ~0.2.1
     tslib: ^2.3.0
@@ -3575,28 +3573,28 @@ __metadata:
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: b7a7d60ee4fbd4b734d2ee2c15ee6ea562e22f9258c8f197687c8d481ead9d610f6a18ef244ba263dcfbca4f7eebe39f23d23f5905873599c336a1e4ba82b03b
+  checksum: 50738dc9a442256393e2f829e8ad8c25a5302d5272a3aaa2711dac84972bd2c613c4f91c03126531c83a24c19aa9dbe7b73e39d1802766dc410c6b51097450fa
   languageName: node
   linkType: hard
 
-"@nrwl/tao@npm:13.9.2, @nrwl/tao@npm:^13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/tao@npm:13.9.2"
+"@nrwl/tao@npm:13.9.5, @nrwl/tao@npm:^13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/tao@npm:13.9.5"
   dependencies:
-    nx: 13.9.2
+    nx: 13.9.5
   bin:
     tao: index.js
-  checksum: af3eb197d2888edfe3d5d29f99915050175df7e1864027d3c209666a2de205b5a095559bdab205ee87da5256e182ded8e17a30f2d0de5705aa4d5c005314beaf
+  checksum: 87cde14f46c267d2f0e0d3409f05f3cf8153b9e0d8ce9b694c8e9ad44ede245f2d3e86cf645bd645a97b4391bc80166e009f4db055fa9be5276c3ba69813e225
   languageName: node
   linkType: hard
 
-"@nrwl/workspace@npm:^13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/workspace@npm:13.9.2"
+"@nrwl/workspace@npm:^13.9.5":
+  version: 13.9.5
+  resolution: "@nrwl/workspace@npm:13.9.5"
   dependencies:
-    "@nrwl/devkit": 13.9.2
-    "@nrwl/jest": 13.9.2
-    "@nrwl/linter": 13.9.2
+    "@nrwl/devkit": 13.9.5
+    "@nrwl/jest": 13.9.5
+    "@nrwl/linter": 13.9.5
     "@parcel/watcher": 2.0.4
     chalk: 4.1.0
     chokidar: ^3.5.1
@@ -3611,7 +3609,7 @@ __metadata:
     ignore: ^5.0.4
     minimatch: 3.0.4
     npm-run-path: ^4.0.1
-    nx: 13.9.2
+    nx: 13.9.5
     open: ^8.4.0
     rxjs: ^6.5.4
     semver: 7.3.4
@@ -3624,7 +3622,7 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 7e8fd96d902f34eabbe57dbb24e57a2d8bc08783e2a5b94af1c9c1de121b79238c92b313db7b9518d2ed1696533f440f501b851e27b68702bc57be2911b2fc92
+  checksum: 444ff082a34231e70fabd9b6c692ed5635327ccacd7a5cb8eb1ef79537ce704b58440ed551cf756471e18cb3862e7d616f4b54e7a3f228805861f6e33fdd22ef
   languageName: node
   linkType: hard
 
@@ -4266,11 +4264,10 @@ __metadata:
   dependencies:
     "@commitlint/cli": ^16.2.3
     "@commitlint/config-conventional": ^16.2.1
-    "@nrwl/cli": ^13.9.2
-    "@nrwl/devkit": ^13.9.2
-    "@nrwl/linter": ^13.9.2
-    "@nrwl/tao": ^13.9.2
-    "@nrwl/workspace": ^13.9.2
+    "@nrwl/devkit": ^13.9.5
+    "@nrwl/linter": ^13.9.5
+    "@nrwl/tao": ^13.9.5
+    "@nrwl/workspace": ^13.9.5
     "@types/jest": ^27.4.1
     "@typescript-eslint/eslint-plugin": ^5.17.0
     "@typescript-eslint/parser": ^5.17.0
@@ -4287,6 +4284,7 @@ __metadata:
     lint-staged: ^12.3.7
     lodash: ^4.17.21
     npm-audit-resolver: ^3.0.0-7
+    nx: ^13.9.5
     prettier: ^2.6.1
     syncpack: ^6.2.0
     typescript: ^4.6.3
@@ -11744,12 +11742,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nx@npm:13.9.2":
-  version: 13.9.2
-  resolution: "nx@npm:13.9.2"
+"nx@npm:13.9.5, nx@npm:^13.9.5":
+  version: 13.9.5
+  resolution: "nx@npm:13.9.5"
   dependencies:
-    "@nrwl/cli": 13.9.2
-    "@nrwl/tao": 13.9.2
+    "@nrwl/cli": 13.9.5
+    "@nrwl/tao": 13.9.5
     "@swc-node/register": ^1.4.2
     "@swc/core": ^1.2.146
     chalk: 4.1.0
@@ -11768,7 +11766,7 @@ __metadata:
     yargs-parser: 20.0.0
   bin:
     nx: bin/nx.js
-  checksum: 3c844c30c8801f9fd17d0d10541e833d891a989807d4711599c610b5e5e4731442a44a21d09800d84173b2699ebc16e50d5bce7e375ff03fe58f24562d5432fd
+  checksum: 9eafb3cc0579fb443e0a5decc490dc3130961ec0e47c005be7fb047033dacc199c26c10c67678fcb75417df6da5d8c1bfe23d8ebf160cd7e45c22dadd34af5cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Release https://github.com/nrwl/nx/releases/tag/13.9.3 remove the nx cli
from @nrwl/cli.
We need to explicitly add the nx dependency now.
