### PR TITLE
feat: add eslint rule to import aws-sdk

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,10 @@ module.exports = {
             message: 'Please use lodash/{module} import instead',
           },
           {
+            name: 'aws-sdk',
+            message: 'Please use aws-sdk/{module} import instead',
+          },
+          {
             name: '.',
             message: 'Please use explicit import file',
           },


### PR DESCRIPTION
This PR adds a simple eslint rule to forbid the import of aws-sdk variables from the root (just like lodash).
It should resolves this [issue](https://github.com/swarmion/template/issues/161)