### PR TITLE
Speed up CI: single build job

### DIFF
--- a/.github/actions/get-project-changes/action.yml
+++ b/.github/actions/get-project-changes/action.yml
@@ -10,12 +10,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-    - name: Cache node_modules
-      uses: ./.github/actions/cache-node-modules
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v2
     - name: Get affected apps

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -3,12 +3,6 @@ description: 'Package all libraries in the monorepo'
 runs:
   using: 'composite'
   steps:
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-    - name: Use cached node_modules
-      uses: ./.github/actions/cache-node-modules
     - name: Cache package builds
       id: package-cache
       uses: ./.github/actions/cache-package-builds

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,22 +18,10 @@ defaults:
     shell: bash
 
 jobs:
-  install-dependencies:
-    name: 🏗 Install dependencies
+  build:
+    name: 🏗 Build Project
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install & cache node dependencies
-        uses: ./.github/actions/install-node-deps
-
-  changes:
-    name: 🗒 Get modified packages
-    needs: install-dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     outputs:
       affected_apps: ${{ steps.get-project-changes.outputs.affected_apps }}
       affected_libs: ${{ steps.get-project-changes.outputs.affected_libs }}
@@ -43,32 +31,24 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
+      - name: Install & cache node dependencies
+        uses: ./.github/actions/install-node-deps
+      - name: Package and cache builds
+        uses: ./.github/actions/package
       - name: Get project changes
         id: get-project-changes
         uses: ./.github/actions/get-project-changes
 
-  package:
-    name: 📦 Package
-    needs: install-dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Package and cache builds
-        uses: ./.github/actions/package
-
   app-lint-and-tests:
     name: 🏛 App Tests
-    needs: [package, changes]
+    needs: build
     runs-on: ubuntu-latest
-    if: join(fromJson(needs.changes.outputs.affected_apps)) != ''
+    if: join(fromJson(needs.build.outputs.affected_apps)) != ''
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        AFFECTED_APP: ${{ fromJson(needs.changes.outputs.affected_apps) }}
+        AFFECTED_APP: ${{ fromJson(needs.build.outputs.affected_apps) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -80,14 +60,14 @@ jobs:
 
   library-lint-and-tests:
     name: 📚 Library Tests
-    needs: [package, changes]
+    needs: build
     runs-on: ubuntu-latest
-    if: join(fromJson(needs.changes.outputs.affected_libs)) != ''
+    if: join(fromJson(needs.build.outputs.affected_libs)) != ''
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        AFFECTED_LIB: ${{ fromJson(needs.changes.outputs.affected_libs) }}
+        AFFECTED_LIB: ${{ fromJson(needs.build.outputs.affected_libs) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -101,18 +81,12 @@ jobs:
     name: ✅ Validate the PR
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [library-lint-and-tests, app-lint-and-tests, package, changes]
+    needs: [build, library-lint-and-tests, app-lint-and-tests]
     steps:
-      - name: Validate package
+      - name: Validate build
         run: |
-          if [[ ${{ needs.package.result }} = "failure" ]]; then
-            echo "Package failed"
-            exit 1
-          fi
-      - name: Validate changes
-        run: |
-          if [[ ${{ needs.changes.result }} = "failure" ]]; then
-            echo "Changes failed"
+          if [[ ${{ needs.build.result }} = "failure" ]]; then
+            echo "build failed"
             exit 1
           fi
       - name: Validate app tests


### PR DESCRIPTION
The idea here is to merge current CI steps `install-dependencies`, `package` & `changes` into a single `build` job.

Why? Because these jobs are actually not doing much on their own, they are implicitly linked to each others, and they are all required before we can continue the CI pipeline.

By merging them into a single job we are saving some CI time, as we don't need to push & pull the Node.js cache (from `install-dependencies`) before detecting `changes` or `packaging` the project.

As the monorepo gets larger, the time saved could build up considerably 🚀 
On this current template monorepo, I was able to shave **~1 minute** from CI runtime.

Let me know what you think 😀

--------

[Current CI configuration](https://github.com/qhello/swarmion-template/actions/runs/2252886668)

![image](https://user-images.githubusercontent.com/9997584/166139747-e14ede69-3c26-449c-88f9-c39c12a90d13.png)


[New CI configuration](https://github.com/qhello/swarmion-template/actions/runs/2252892894)

![image](https://user-images.githubusercontent.com/9997584/166139739-ae41673b-04c5-478c-a119-aad500982822.png)

