### PR TITLE
feat(code-splitting): import lazily home to enforce best practices

### DIFF
--- a/frontend/app/src/AppRoutes.tsx
+++ b/frontend/app/src/AppRoutes.tsx
@@ -1,20 +1,23 @@
+import React, { Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { NotFound } from '@swarmion-starter/frontend-shared';
 
-import { Home } from 'pages';
+const Home = React.lazy(() => import('pages/Home/Home'));
 
 export enum RoutePaths {
   HOME_PAGE = '/',
 }
 
 const AppRoutes = (): JSX.Element => (
-  <BrowserRouter>
-    <Routes>
-      <Route path={RoutePaths.HOME_PAGE} element={<Home />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
-  </BrowserRouter>
+  <Suspense fallback={NotFound}>
+    <BrowserRouter>
+      <Routes>
+        <Route path={RoutePaths.HOME_PAGE} element={<Home />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </BrowserRouter>
+  </Suspense>
 );
 
 export default AppRoutes;


### PR DESCRIPTION
Hello Swarmion team !

While using Swarmion template, I forgot to code split my react routes for a while.
I think it would help new user to have a working example of a code splitted route by default in the template

