### PR TITLE
chore: remove global watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test-circular": "nx run-many --target=test-circular --all --parallel=4",
     "test-linter": "nx run-many --target=test-linter --all --parallel=4",
     "test-type": "nx run-many --target=test-type --all --parallel=4",
-    "test-unit": "nx run-many --target=test-unit --all --parallel=4",
-    "watch": "nx run-many --target=watch --all  --parallel=4"
+    "test-unit": "nx run-many --target=test-unit --all --parallel=4"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.4",


### PR DESCRIPTION
Only the 4 first packages would be watched, this command should never be executed.

