### PR TITLE
refactor: move RoutePaths definition

### DIFF
--- a/frontend/app/src/AppRoutes.tsx
+++ b/frontend/app/src/AppRoutes.tsx
@@ -3,11 +3,9 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { NotFound } from '@swarmion-starter/frontend-shared';
 
-const Home = React.lazy(() => import('pages/Home/Home'));
+import { RoutePaths } from 'types';
 
-export enum RoutePaths {
-  HOME_PAGE = '/',
-}
+const Home = React.lazy(() => import('pages/Home/Home'));
 
 const AppRoutes = (): JSX.Element => (
   <Suspense fallback={NotFound}>

--- a/frontend/app/src/types/RoutePaths.ts
+++ b/frontend/app/src/types/RoutePaths.ts
@@ -1,0 +1,4 @@
+// RoutePaths is defined here and not in AppRoutes.tsx to prevent circular dependencies
+export enum RoutePaths {
+  HOME_PAGE = '/',
+}

--- a/frontend/app/src/types/index.ts
+++ b/frontend/app/src/types/index.ts
@@ -1,0 +1,1 @@
+export { RoutePaths } from './RoutePaths';


### PR DESCRIPTION
This moves RoutePaths definition out of AppRoutes.tsx to prevent circular dependencies.